### PR TITLE
Use numpy to calculate simhash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@ setup(
     packages = find_packages(),
     include_package_data = True,
     platforms = 'any',
-    install_requires = [],
+    install_requires = [
+        'numpy',
+    ],
     tests_require = [
         'nose',
-        'numpy',
         'scipy',
         'scikit-learn',
         ],


### PR DESCRIPTION
Per #49, here is code to use numpy for calculating simhashes.

The numpy example code in #49 gets a little longer here in order to handle batching to reduce ram usage, and add a fallback for large weights and non-integer weights. But the basic idea is the same: convert a bunch of hashes at once to a single byte string, then hand the byte string off to numpy to unpack into bits and sum columns.

Across a range of benchmarks (using character shingles or word shingles with or without pre-counted weights), the new code runs in 21% to 29% the time of the old code, i.e. a speedup of 3x to 4x. The one exception is when the features have non-integer weights, where we don't gain much from this approach; there we only speed up a little bit, and run in 85% the time of the old code.

In the simplest case of simhashing a list of strings, in the old code, the actual utf encoding and hashing accounts for less than 20% of total run time. In the new code it accounts for over 70% of the run time. So simhashing time is now dominated by the speed of hashing rather than the speed of the simhash algorithm.

Other optimizations applied:

* No longer `assert isinstance(f, collections.Iterable)`, but just let `f, w = f` fail if the type is wrong. Cuts about 20% off the new run time.
* `hashfunc` is permitted to return either a byte string or an integer, and default `_hashfunc` returns a byte string. Cuts about 20% off the new run time.

API changes:

* The bit length `f` is now required to be a multiple of 8, so outputs of `hashfunc` can be processed as bytes.

I added `numpy` as a requirement to `setup.py`, but didn't actually test the install process in a blank virtualenv. 😬

During development I used this benchmark.py script to check runtime and confirm that old and new versions returned the same answers on random inputs:

```
import hashlib
import random
import string
from collections import Counter

from tqdm import tqdm

import simhash as simhash_new
import simhash_old
import timeit

# To install simhash_old:
# pip install simhash
# SITE_PACKAGES=`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
# mv $SITE_PACKAGES/simhash $SITE_PACKAGES/simhash_old
# mv $SITE_PACKAGES/simhash-1.11.0.dist-info $SITE_PACKAGES/simhash_old-1.11.0.dist-info

def old_hashfunc(x):
    return int(hashlib.md5(x).hexdigest(), 16)

def bench(s):
    print(s)
    return min(timeit.Timer(s, globals=globals()).repeat(7, 10))

def shingles(tokens, n):
    return zip(*[tokens[i:-n + i + 1 or None] for i in range(n)])


word_shingles = ['the unanimous declaration', 'unanimous declaration of', 'declaration of the', 'of the thirteen', 'the thirteen united', 'thirteen united states', 'united states of', 'states of america', 'of america when', 'america when in', 'when in the', 'in the course', 'the course of', 'course of human', 'of human events', 'human events it', 'events it becomes', 'it becomes necessary', 'becomes necessary for', 'necessary for one', 'for one people', 'one people to', 'people to dissolve', 'to dissolve the', 'dissolve the political', 'the political bands', 'political bands which', 'bands which have', 'which have connected', 'have connected them', 'connected them with', 'them with another', 'with another and', 'another and to', 'and to assume', 'to assume among', 'assume among the', 'among the powers', 'the powers of', 'powers of the', 'of the earth', 'the earth the', 'earth the separate', 'the separate and', 'separate and equal', 'and equal station', 'equal station to', 'station to which', 'to which the', 'which the laws', 'the laws of', 'laws of nature', 'of nature and', 'nature and of', 'and of nature', 'of nature s', 'nature s god', 's god entitle', 'god entitle them', 'entitle them a', 'them a decent', 'a decent respect', 'decent respect to', 'respect to the', 'to the opinions', 'the opinions of', 'opinions of mankind', 'of mankind requires', 'mankind requires that', 'requires that they', 'that they should', 'they should declare', 'should declare the', 'declare the causes', 'the causes which', 'causes which impel', 'which impel them', 'impel them to', 'them to the', 'to the separation', 'the separation we', 'separation we hold', 'we hold these', 'hold these truths', 'these truths to', 'truths to be', 'to be self', 'be self evident', 'self evident that', 'evident that all', 'that all men', 'all men are', 'men are created', 'are created equal', 'created equal that', 'equal that they', 'that they are', 'they are endowed', 'are endowed by', 'endowed by their', 'by their creator', 'their creator with', 'creator with certain', 'with certain unalienable', 'certain unalienable rights', 'unalienable rights that', 'rights that among', 'that among these', 'among these are', 'these are life', 'are life liberty', 'life liberty and', 'liberty and the', 'and the pursuit', 'the pursuit of', 'pursuit of happiness', 'of happiness that', 'happiness that to', 'that to secure', 'to secure these', 'secure these rights', 'these rights governments', 'rights governments are', 'governments are instituted', 'are instituted among', 'instituted among men', 'among men deriving', 'men deriving their', 'deriving their just', 'their just powers', 'just powers from', 'powers from the', 'from the consent', 'the consent of', 'consent of the', 'of the governed', 'the governed that', 'governed that whenever', 'that whenever any', 'whenever any form', 'any form of', 'form of government', 'of government becomes', 'government becomes destructive', 'becomes destructive of', 'destructive of these', 'of these ends', 'these ends it', 'ends it is', 'it is the', 'is the right', 'the right of', 'right of the', 'of the people', 'the people to', 'people to alter', 'to alter or', 'alter or to', 'or to abolish', 'to abolish it', 'abolish it and', 'it and to', 'and to institute', 'to institute new', 'institute new government', 'new government laying', 'government laying its', 'laying its foundation', 'its foundation on', 'foundation on such', 'on such principles', 'such principles and', 'principles and organizing', 'and organizing its', 'organizing its powers', 'its powers in', 'powers in such', 'in such form', 'such form as', 'form as to', 'as to them', 'to them shall', 'them shall seem', 'shall seem most', 'seem most likely', 'most likely to', 'likely to effect', 'to effect their', 'effect their safety', 'their safety and', 'safety and happiness', 'and happiness prudence', 'happiness prudence indeed', 'prudence indeed will', 'indeed will dictate', 'will dictate that', 'dictate that governments', 'that governments long', 'governments long established', 'long established should', 'established should not', 'should not be', 'not be changed', 'be changed for', 'changed for light', 'for light and', 'light and transient', 'and transient causes', 'transient causes and', 'causes and accordingly', 'and accordingly all', 'accordingly all experience', 'all experience hath', 'experience hath shewn', 'hath shewn that', 'shewn that mankind', 'that mankind are', 'mankind are more', 'are more disposed', 'more disposed to', 'disposed to suffer', 'to suffer while', 'suffer while evils', 'while evils are', 'evils are sufferable', 'are sufferable than', 'sufferable than to', 'than to right', 'to right themselves', 'right themselves by', 'themselves by abolishing', 'by abolishing the', 'abolishing the forms', 'the forms to', 'forms to which', 'to which they', 'which they are', 'they are accustomed', 'are accustomed but', 'accustomed but when', 'but when a', 'when a long', 'a long train', 'long train of', 'train of abuses', 'of abuses and', 'abuses and usurpations', 'and usurpations pursuing', 'usurpations pursuing invariably', 'pursuing invariably the', 'invariably the same', 'the same object', 'same object evinces', 'object evinces a', 'evinces a design', 'a design to', 'design to reduce', 'to reduce them', 'reduce them under', 'them under absolute', 'under absolute despotism', 'absolute despotism it', 'despotism it is', 'it is their', 'is their right', 'their right it', 'right it is', 'it is their', 'is their duty', 'their duty to', 'duty to throw', 'to throw off', 'throw off such', 'off such government', 'such government and', 'government and to', 'and to provide', 'to provide new', 'provide new guards', 'new guards for', 'guards for their', 'for their future', 'their future security', 'future security such', 'security such has', 'such has been', 'has been the', 'been the patient', 'the patient sufferance', 'patient sufferance of', 'sufferance of these', 'of these colonies', 'these colonies and', 'colonies and such', 'and such is', 'such is now', 'is now the', 'now the necessity', 'the necessity which', 'necessity which constrains', 'which constrains them', 'constrains them to', 'them to alter', 'to alter their', 'alter their former', 'their former systems', 'former systems of', 'systems of government', 'of government the', 'government the history', 'the history of', 'history of the', 'of the present', 'the present king', 'present king of', 'king of great', 'of great britain', 'great britain is', 'britain is a', 'is a history', 'a history of', 'history of repeated', 'of repeated injuries', 'repeated injuries and', 'injuries and usurpations', 'and usurpations all', 'usurpations all having', 'all having in', 'having in direct', 'in direct object', 'direct object the', 'object the establishment', 'the establishment of', 'establishment of an', 'of an absolute', 'an absolute tyranny', 'absolute tyranny over', 'tyranny over these', 'over these states', 'these states to', 'states to prove', 'to prove this', 'prove this let', 'this let facts', 'let facts be', 'facts be submitted', 'be submitted to', 'submitted to a', 'to a candid', 'a candid world', 'candid world he', 'world he has', 'he has refused', 'has refused his', 'refused his assent', 'his assent to', 'assent to laws', 'to laws the', 'laws the most', 'the most wholesome', 'most wholesome and', 'wholesome and necessary', 'and necessary for', 'necessary for the', 'for the public', 'the public good', 'public good he', 'good he has', 'he has forbidden', 'has forbidden his', 'forbidden his governors', 'his governors to', 'governors to pass', 'to pass laws', 'pass laws of', 'laws of immediate', 'of immediate and', 'immediate and pressing', 'and pressing importance', 'pressing importance unless', 'importance unless suspended', 'unless suspended in', 'suspended in their', 'in their operation', 'their operation till', 'operation till his', 'till his assent', 'his assent should', 'assent should be', 'should be obtained', 'be obtained and', 'obtained and when', 'and when so', 'when so suspended', 'so suspended he', 'suspended he has', 'he has utterly', 'has utterly neglected', 'utterly neglected to', 'neglected to attend', 'to attend to', 'attend to them', 'to them he', 'them he has', 'he has refused', 'has refused to', 'refused to pass', 'to pass other', 'pass other laws', 'other laws for', 'laws for the', 'for the accommodation', 'the accommodation of', 'accommodation of large', 'of large districts', 'large districts of', 'districts of people', 'of people unless', 'people unless those', 'unless those people', 'those people would', 'people would relinquish', 'would relinquish the', 'relinquish the right', 'the right of', 'right of representation', 'of representation in', 'representation in the', 'in the legislature', 'the legislature a', 'legislature a right', 'a right inestimable', 'right inestimable to', 'inestimable to them', 'to them and', 'them and formidable', 'and formidable to', 'formidable to tyrants', 'to tyrants only', 'tyrants only he', 'only he has', 'he has called', 'has called together', 'called together legislative', 'together legislative bodies', 'legislative bodies at', 'bodies at places', 'at places unusual', 'places unusual uncomfortable', 'unusual uncomfortable and', 'uncomfortable and distant', 'and distant from', 'distant from the', 'from the depository', 'the depository of', 'depository of their', 'of their public', 'their public records', 'public records for', 'records for the', 'for the sole', 'the sole purpose', 'sole purpose of', 'purpose of fatiguing', 'of fatiguing them', 'fatiguing them into', 'them into compliance', 'into compliance with', 'compliance with his', 'with his measures', 'his measures he', 'measures he has', 'he has dissolved', 'has dissolved representative', 'dissolved representative houses', 'representative houses repeatedly', 'houses repeatedly for', 'repeatedly for opposing', 'for opposing with', 'opposing with manly', 'with manly firmness', 'manly firmness his', 'firmness his invasions', 'his invasions on', 'invasions on the', 'on the rights', 'the rights of', 'rights of the', 'of the people', 'the people he', 'people he has', 'he has refused', 'has refused for', 'refused for a', 'for a long', 'a long time', 'long time after', 'time after such', 'after such dissolutions', 'such dissolutions to', 'dissolutions to cause', 'to cause others', 'cause others to', 'others to be', 'to be elected', 'be elected whereby', 'elected whereby the', 'whereby the legislative', 'the legislative powers', 'legislative powers incapable', 'powers incapable of', 'incapable of annihilation', 'of annihilation have', 'annihilation have returned', 'have returned to', 'returned to the', 'to the people', 'the people at', 'people at large', 'at large for', 'large for their', 'for their exercise', 'their exercise the', 'exercise the state', 'the state remaining', 'state remaining in', 'remaining in the', 'in the mean', 'the mean time', 'mean time exposed', 'time exposed to', 'exposed to all', 'to all the', 'all the dangers', 'the dangers of', 'dangers of invasion', 'of invasion from', 'invasion from without', 'from without and', 'without and convulsions', 'and convulsions within', 'convulsions within he', 'within he has', 'he has endeavoured', 'has endeavoured to', 'endeavoured to prevent', 'to prevent the', 'prevent the population', 'the population of', 'population of these', 'of these states', 'these states for', 'states for that', 'for that purpose', 'that purpose obstructing', 'purpose obstructing the', 'obstructing the laws', 'the laws for', 'laws for naturalization', 'for naturalization of', 'naturalization of foreigners', 'of foreigners refusing', 'foreigners refusing to', 'refusing to pass', 'to pass others', 'pass others to', 'others to encourage', 'to encourage their', 'encourage their migrations', 'their migrations hither', 'migrations hither and', 'hither and raising', 'and raising the', 'raising the conditions', 'the conditions of', 'conditions of new', 'of new appropriations', 'new appropriations of', 'appropriations of lands', 'of lands he', 'lands he has', 'he has obstructed', 'has obstructed the', 'obstructed the administration', 'the administration of', 'administration of justice', 'of justice by', 'justice by refusing', 'by refusing his', 'refusing his assent', 'his assent to', 'assent to laws', 'to laws for', 'laws for establishing', 'for establishing judiciary', 'establishing judiciary powers', 'judiciary powers he', 'powers he has', 'he has made', 'has made judges', 'made judges dependent', 'judges dependent on', 'dependent on his', 'on his will', 'his will alone', 'will alone for', 'alone for the', 'for the tenure', 'the tenure of', 'tenure of their', 'of their offices', 'their offices and', 'offices and the', 'and the amount', 'the amount and', 'amount and payment', 'and payment of', 'payment of their', 'of their salaries', 'their salaries he', 'salaries he has', 'he has erected', 'has erected a', 'erected a multitude', 'a multitude of', 'multitude of new', 'of new offices', 'new offices and', 'offices and sent', 'and sent hither', 'sent hither swarms', 'hither swarms of', 'swarms of officers', 'of officers to', 'officers to harrass', 'to harrass our', 'harrass our people', 'our people and', 'people and eat', 'and eat out', 'eat out their', 'out their substance', 'their substance he', 'substance he has', 'he has kept', 'has kept among', 'kept among us', 'among us in', 'us in times', 'in times of', 'times of peace', 'of peace standing', 'peace standing armies', 'standing armies without', 'armies without the', 'without the consent', 'the consent of', 'consent of our', 'of our legislatures', 'our legislatures he', 'legislatures he has', 'he has affected', 'has affected to', 'affected to render', 'to render the', 'render the military', 'the military independent', 'military independent of', 'independent of and', 'of and superior', 'and superior to', 'superior to the', 'to the civil', 'the civil power', 'civil power he', 'power he has', 'he has combined', 'has combined with', 'combined with others', 'with others to', 'others to subject', 'to subject us', 'subject us to', 'us to a', 'to a jurisdiction', 'a jurisdiction foreign', 'jurisdiction foreign to', 'foreign to our', 'to our constitution', 'our constitution and', 'constitution and unacknowledged', 'and unacknowledged by', 'unacknowledged by our', 'by our laws', 'our laws giving', 'laws giving his', 'giving his assent', 'his assent to', 'assent to their', 'to their acts', 'their acts of', 'acts of pretended', 'of pretended legislation', 'pretended legislation for', 'legislation for quartering', 'for quartering large', 'quartering large bodies', 'large bodies of', 'bodies of armed', 'of armed troops', 'armed troops among', 'troops among us', 'among us for', 'us for protecting', 'for protecting them', 'protecting them by', 'them by a', 'by a mock', 'a mock trial', 'mock trial from', 'trial from punishment', 'from punishment for', 'punishment for any', 'for any murders', 'any murders which', 'murders which they', 'which they should', 'they should commit', 'should commit on', 'commit on the', 'on the inhabitants', 'the inhabitants of', 'inhabitants of these', 'of these states', 'these states for', 'states for cutting', 'for cutting off', 'cutting off our', 'off our trade', 'our trade with', 'trade with all', 'with all parts', 'all parts of', 'parts of the', 'of the world', 'the world for', 'world for imposing', 'for imposing taxes', 'imposing taxes on', 'taxes on us', 'on us without', 'us without our', 'without our consent', 'our consent for', 'consent for depriving', 'for depriving us', 'depriving us in', 'us in many', 'in many cases', 'many cases of', 'cases of the', 'of the benefits', 'the benefits of', 'benefits of trial', 'of trial by', 'trial by jury', 'by jury for', 'jury for transporting', 'for transporting us', 'transporting us beyond', 'us beyond seas', 'beyond seas to', 'seas to be', 'to be tried', 'be tried for', 'tried for pretended', 'for pretended offences', 'pretended offences for', 'offences for abolishing', 'for abolishing the', 'abolishing the free', 'the free system', 'free system of', 'system of english', 'of english laws', 'english laws in', 'laws in a', 'in a neighbouring', 'a neighbouring province', 'neighbouring province establishing', 'province establishing therein', 'establishing therein an', 'therein an arbitrary', 'an arbitrary government', 'arbitrary government and', 'government and enlarging', 'and enlarging its', 'enlarging its boundaries', 'its boundaries so', 'boundaries so as', 'so as to', 'as to render', 'to render it', 'render it at', 'it at once', 'at once an', 'once an example', 'an example and', 'example and fit', 'and fit instrument', 'fit instrument for', 'instrument for introducing', 'for introducing the', 'introducing the same', 'the same absolute', 'same absolute rule', 'absolute rule into', 'rule into these', 'into these colonies', 'these colonies for', 'colonies for taking', 'for taking away', 'taking away our', 'away our charters', 'our charters abolishing', 'charters abolishing our', 'abolishing our most', 'our most valuable', 'most valuable laws', 'valuable laws and', 'laws and altering', 'and altering fundamentally', 'altering fundamentally the', 'fundamentally the forms', 'the forms of', 'forms of our', 'of our governments', 'our governments for', 'governments for suspending', 'for suspending our', 'suspending our own', 'our own legislatures', 'own legislatures and', 'legislatures and declaring', 'and declaring themselves', 'declaring themselves invested', 'themselves invested with', 'invested with power', 'with power to', 'power to legislate', 'to legislate for', 'legislate for us', 'for us in', 'us in all', 'in all cases', 'all cases whatsoever', 'cases whatsoever he', 'whatsoever he has', 'he has abdicated', 'has abdicated government', 'abdicated government here', 'government here by', 'here by declaring', 'by declaring us', 'declaring us out', 'us out of', 'out of his', 'of his protection', 'his protection and', 'protection and waging', 'and waging war', 'waging war against', 'war against us', 'against us he', 'us he has', 'he has plundered', 'has plundered our', 'plundered our seas', 'our seas ravaged', 'seas ravaged our', 'ravaged our coasts', 'our coasts burnt', 'coasts burnt our', 'burnt our towns', 'our towns and', 'towns and destroyed', 'and destroyed the', 'destroyed the lives', 'the lives of', 'lives of our', 'of our people', 'our people he', 'people he is', 'he is at', 'is at this', 'at this time', 'this time transporting', 'time transporting large', 'transporting large armies', 'large armies of', 'armies of foreign', 'of foreign mercenaries', 'foreign mercenaries to', 'mercenaries to compleat', 'to compleat the', 'compleat the works', 'the works of', 'works of death', 'of death desolation', 'death desolation and', 'desolation and tyranny', 'and tyranny already', 'tyranny already begun', 'already begun with', 'begun with circumstances', 'with circumstances of', 'circumstances of cruelty', 'of cruelty perfidy', 'cruelty perfidy scarcely', 'perfidy scarcely paralleled', 'scarcely paralleled in', 'paralleled in the', 'in the most', 'the most barbarous', 'most barbarous ages', 'barbarous ages and', 'ages and totally', 'and totally unworthy', 'totally unworthy the', 'unworthy the head', 'the head of', 'head of a', 'of a civilized', 'a civilized nation', 'civilized nation he', 'nation he has', 'he has constrained', 'has constrained our', 'constrained our fellow', 'our fellow citizens', 'fellow citizens taken', 'citizens taken captive', 'taken captive on', 'captive on the', 'on the high', 'the high seas', 'high seas to', 'seas to bear', 'to bear arms', 'bear arms against', 'arms against their', 'against their country', 'their country to', 'country to become', 'to become the', 'become the executioners', 'the executioners of', 'executioners of their', 'of their friends', 'their friends and', 'friends and brethren', 'and brethren or', 'brethren or to', 'or to fall', 'to fall themselves', 'fall themselves by', 'themselves by their', 'by their hands', 'their hands he', 'hands he has', 'he has excited', 'has excited domestic', 'excited domestic insurrections', 'domestic insurrections amongst', 'insurrections amongst us', 'amongst us and', 'us and has', 'and has endeavoured', 'has endeavoured to', 'endeavoured to bring', 'to bring on', 'bring on the', 'on the inhabitants', 'the inhabitants of', 'inhabitants of our', 'of our frontiers', 'our frontiers the', 'frontiers the merciless', 'the merciless indian', 'merciless indian savages', 'indian savages whose', 'savages whose known', 'whose known rule', 'known rule of', 'rule of warfare', 'of warfare is', 'warfare is an', 'is an undistinguished', 'an undistinguished destruction', 'undistinguished destruction of', 'destruction of all', 'of all ages', 'all ages sexes', 'ages sexes and', 'sexes and conditions', 'and conditions in', 'conditions in every', 'in every stage', 'every stage of', 'stage of these', 'of these oppressions', 'these oppressions we', 'oppressions we have', 'we have petitioned', 'have petitioned for', 'petitioned for redress', 'for redress in', 'redress in the', 'in the most', 'the most humble', 'most humble terms', 'humble terms our', 'terms our repeated', 'our repeated petitions', 'repeated petitions have', 'petitions have been', 'have been answered', 'been answered only', 'answered only by', 'only by repeated', 'by repeated injury', 'repeated injury a', 'injury a prince', 'a prince whose', 'prince whose character', 'whose character is', 'character is thus', 'is thus marked', 'thus marked by', 'marked by every', 'by every act', 'every act which', 'act which may', 'which may define', 'may define a', 'define a tyrant', 'a tyrant is', 'tyrant is unfit', 'is unfit to', 'unfit to be', 'to be the', 'be the ruler', 'the ruler of', 'ruler of a', 'of a free', 'a free people', 'free people nor', 'people nor have', 'nor have we', 'have we been', 'we been wanting', 'been wanting in', 'wanting in attentions', 'in attentions to', 'attentions to our', 'to our brittish', 'our brittish brethren', 'brittish brethren we', 'brethren we have', 'we have warned', 'have warned them', 'warned them from', 'them from time', 'from time to', 'time to time', 'to time of', 'time of attempts', 'of attempts by', 'attempts by their', 'by their legislature', 'their legislature to', 'legislature to extend', 'to extend an', 'extend an unwarrantable', 'an unwarrantable jurisdiction', 'unwarrantable jurisdiction over', 'jurisdiction over us', 'over us we', 'us we have', 'we have reminded', 'have reminded them', 'reminded them of', 'them of the', 'of the circumstances', 'the circumstances of', 'circumstances of our', 'of our emigration', 'our emigration and', 'emigration and settlement', 'and settlement here', 'settlement here we', 'here we have', 'we have appealed', 'have appealed to', 'appealed to their', 'to their native', 'their native justice', 'native justice and', 'justice and magnanimity', 'and magnanimity and', 'magnanimity and we', 'and we have', 'we have conjured', 'have conjured them', 'conjured them by', 'them by the', 'by the ties', 'the ties of', 'ties of our', 'of our common', 'our common kindred', 'common kindred to', 'kindred to disavow', 'to disavow these', 'disavow these usurpations', 'these usurpations which', 'usurpations which would', 'which would inevitably', 'would inevitably interrupt', 'inevitably interrupt our', 'interrupt our connections', 'our connections and', 'connections and correspondence', 'and correspondence they', 'correspondence they too', 'they too have', 'too have been', 'have been deaf', 'been deaf to', 'deaf to the', 'to the voice', 'the voice of', 'voice of justice', 'of justice and', 'justice and of', 'and of consanguinity', 'of consanguinity we', 'consanguinity we must', 'we must therefore', 'must therefore acquiesce', 'therefore acquiesce in', 'acquiesce in the', 'in the necessity', 'the necessity which', 'necessity which denounces', 'which denounces our', 'denounces our separation', 'our separation and', 'separation and hold', 'and hold them', 'hold them as', 'them as we', 'as we hold', 'we hold the', 'hold the rest', 'the rest of', 'rest of mankind', 'of mankind enemies', 'mankind enemies in', 'enemies in war', 'in war in', 'war in peace', 'in peace friends', 'peace friends we', 'friends we therefore', 'we therefore the', 'therefore the representatives', 'the representatives of', 'representatives of the', 'of the united', 'the united states', 'united states of', 'states of america', 'of america in', 'america in general', 'in general congress', 'general congress assembled', 'congress assembled appealing', 'assembled appealing to', 'appealing to the', 'to the supreme', 'the supreme judge', 'supreme judge of', 'judge of the', 'of the world', 'the world for', 'world for the', 'for the rectitude', 'the rectitude of', 'rectitude of our', 'of our intentions', 'our intentions do', 'intentions do in', 'do in the', 'in the name', 'the name and', 'name and by', 'and by authority', 'by authority of', 'authority of the', 'of the good', 'the good people', 'good people of', 'people of these', 'of these colonies', 'these colonies solemnly', 'colonies solemnly publish', 'solemnly publish and', 'publish and declare', 'and declare that', 'declare that these', 'that these united', 'these united colonies', 'united colonies are', 'colonies are and', 'are and of', 'and of right', 'of right ought', 'right ought to', 'ought to be', 'to be free', 'be free and', 'free and independent', 'and independent states', 'independent states that', 'states that they', 'that they are', 'they are absolved', 'are absolved from', 'absolved from all', 'from all allegiance', 'all allegiance to', 'allegiance to the', 'to the british', 'the british crown', 'british crown and', 'crown and that', 'and that all', 'that all political', 'all political connection', 'political connection between', 'connection between them', 'between them and', 'them and the', 'and the state', 'the state of', 'state of great', 'of great britain', 'great britain is', 'britain is and', 'is and ought', 'and ought to', 'ought to be', 'to be totally', 'be totally dissolved', 'totally dissolved and', 'dissolved and that', 'and that as', 'that as free', 'as free and', 'free and independent', 'and independent states', 'independent states they', 'states they have', 'they have full', 'have full power', 'full power to', 'power to levy', 'to levy war', 'levy war conclude', 'war conclude peace', 'conclude peace contract', 'peace contract alliances', 'contract alliances establish', 'alliances establish commerce', 'establish commerce and', 'commerce and to', 'and to do', 'to do all', 'do all other', 'all other acts', 'other acts and', 'acts and things', 'and things which', 'things which independent', 'which independent states', 'independent states may', 'states may of', 'may of right', 'of right do', 'right do and', 'do and for', 'and for the', 'for the support', 'the support of', 'support of this', 'of this declaration', 'this declaration with', 'declaration with a', 'with a firm', 'a firm reliance', 'firm reliance on', 'reliance on the', 'on the protection', 'the protection of', 'protection of divine', 'of divine providence', 'divine providence we', 'providence we mutually', 'we mutually pledge', 'mutually pledge to', 'pledge to each', 'to each other', 'each other our', 'other our lives', 'our lives our', 'lives our fortunes', 'our fortunes and', 'fortunes and our', 'and our sacred', 'our sacred honor']
char_shingles = [''.join(i) for i in shingles(' '.join(word_shingles), 3)]
counted_word_shingles = Counter(word_shingles).most_common()
counted_char_shingles = Counter(char_shingles).most_common()
float_word_shingles = [(w, random.random()) for w in word_shingles]

# try 1000 random documents
# print("Trying 1000 random documents for consistency")
# for _ in tqdm(range(1000)):
#     word_shingles = [(
#         ''.join(random.choices(string.ascii_uppercase + string.digits, k=10)),
#         random.randint(1, 10) if random.randint(0, 1) else random.randint(1, 100000) if random.randint(0, 1) else random.random()
#     ) for _ in range(random.randint(100, 2000))]
#     v1 = simhash_old.Simhash(word_shingles)
#     v2 = simhash_new.Simhash(word_shingles)
#     v3 = simhash_new.Simhash(word_shingles, hashfunc=old_hashfunc)
#     if not (v1 == v2 == v3):
#         print(v1.distance(v2))

# Output:
# Trying 1000 random documents for consistency
# 100%|█████| 1000/1000 [00:26<00:00, 37.94it/s]

# print("Benchmarking old library vs. new library")
print(bench("simhash_new.Simhash(word_shingles)") / bench("simhash_old.Simhash(word_shingles)"))
print(bench("simhash_new.Simhash(char_shingles)") / bench("simhash_old.Simhash(char_shingles)"))
print(bench("simhash_new.Simhash(counted_word_shingles)") / bench("simhash_old.Simhash(counted_word_shingles)"))
print(bench("simhash_new.Simhash(counted_char_shingles)") / bench("simhash_old.Simhash(counted_char_shingles)"))
print(bench("simhash_new.Simhash(float_word_shingles)") / bench("simhash_old.Simhash(float_word_shingles)"))

# Output:
# Benchmarking old library vs. new library
# simhash_new.Simhash(word_shingles)
# simhash_old.Simhash(word_shingles)
# 0.23008046620822425
# simhash_new.Simhash(char_shingles)
# simhash_old.Simhash(char_shingles)
# 0.21115480284751534
# simhash_new.Simhash(counted_word_shingles)
# simhash_old.Simhash(counted_word_shingles)
# 0.23055190812210527
# simhash_new.Simhash(counted_char_shingles)
# simhash_old.Simhash(counted_char_shingles)
# 0.2971958341939762
# simhash_new.Simhash(float_word_shingles)
# simhash_old.Simhash(float_word_shingles)
# 0.8543415593908883
```