### PR TITLE
Add concatenation of simhashes

### DIFF
--- a/tests/test_simhash.py
+++ b/tests/test_simhash.py
@@ -111,7 +111,15 @@ class TestSimhash(TestCase):
         many_features_large_weights = [(f, Simhash.large_weight_cutoff * i) for i, f in enumerate(many_features)]
         self.assertEqual(7984652473404407437, Simhash(many_features).value)
         self.assertEqual(3372825719632739723, Simhash(many_features_large_weights).value)
-
+        
+    def test_simhash_concatenation(self):
+        a = Simhash(0xaaaaaaaa, f=32)
+        b = Simhash(0xbbbbbbbb, f=32)
+        c = a.concatenate([b])
+        d = Simhash(0xaaaaaaaabbbbbbbb, f=64)
+        self.assertEqual(c.value,d.value)
+        with self.assertRaises(Exception) as e:
+            a.concatenate(b)
 
 class TestSimhashIndex(TestCase):
     data = {


### PR DESCRIPTION
Add the possibility to concatenate simhashes to make a larger one.

This way one can make a sort of "signature" where multiple simhashes are combined into one.

Just pass the parameter `concatenate` to `True` and the parametere `value` as a list of simhashes when creating the bigger simhash.

Example with 4 simhashes of 32 bits:
```
input_to_concat = [simhash1, simhash2, simhash3, simhas4]
new_simhash =  Simhash(input_to_concat, f=128, concatenate=True)
```