### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ setup(
     license = 'MIT License',
 
     url = 'http://leons.im/posts/a-python-implementation-of-simhash-algorithm/',
+    project_urls={
+        'Source': 'https://github.com/1e0ng/simhash',
+    },
     author = '1e0n',
     author_email = 'i@leons.im',
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license = 'MIT License',
 
     url = 'http://leons.im/posts/a-python-implementation-of-simhash-algorithm/',
-    project_urls={
+    project_urls = {
         'Source': 'https://github.com/1e0ng/simhash',
     },
     author = '1e0n',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)